### PR TITLE
Added `/interface wireless` line to make configuration more modular

### DIFF
--- a/prodnet/wap/wap-ap.rsc
+++ b/prodnet/wap/wap-ap.rsc
@@ -66,6 +66,7 @@ mode=ap-bridge \
 ssid="dwebcamp 2.4G" \
 security-profile=default
 
+/interface wireless
 set [ find default-name=wlan2 ] \
 disabled=no \
 country="united states3" \


### PR DESCRIPTION
The commands are more modular now, and can be copy/pasted more easily in stages as described in https://github.com/dweb-camp-2019/meshnet/blob/master/prodnet/README.md