### PR TITLE
Add contact email

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ The technical design of the mesh network is documented in [Section 2](2.0-networ
 ![mesh-welcome](images/mesh-welcome.jpg)
 
 We hope this documentation will serve as a reference and inspire future instances of participatory networks at events and communities.
+If you have feedback or would like to learn more about this project, please email [hello [at] hypha.coop](mailto:hello@hypha.coop) to get in touch!
 
 ### Licenses
 


### PR DESCRIPTION
@whanamura suggested that I add a contact email before publicly announcing the website, so anyone who wants to learn more can get in touch. This also means whoever is behind this email will be responsible for handling all the incoming inquiries.

I can commit to long-term stewardship of this site through hypha.coop, which I would expect to be low maintenance since it is just an archive of the 2019 instance. This email address also goes to other members of Hypha like @DarkDrgn2k who are knowledgeable of the technical aspects of project, and many people in the org are connected to the projects / people described in the document should we need to make connections.